### PR TITLE
Adjust collision shape description

### DIFF
--- a/_data/release_4_6/features.yml
+++ b/_data/release_4_6/features.yml
@@ -851,7 +851,7 @@ mesh_to_collision_shape:
   text: |
     So far, to get a collision shape from a primitive mesh, you had to manually choose a shape type and align it by hand. Literally a drag... But no more.
 
-    Starting Godot 4.6, whenever your mesh is a simple geometric shape like a box, sphere, cylinder, capsule, or another supported primitive shape, you can now automatically generate a matching CollisionShape3D. One more quality-of-life boost!
+    Starting Godot 4.6, whenever your mesh is a simple geometric shape like a box, sphere, cylinder, or capsule, you can now automatically generate a matching CollisionShape3D from the Mesh menu. One more quality-of-life boost!
 
   read_more: https://github.com/godotengine/godot/pull/101521
   contributors:


### PR DESCRIPTION
The four shapes listed (box, sphere, cylinder, and capsule) are the only PrimitiveMesh types that are supported.
And now mentions that this is in the Mesh menu, as suggested in RC, to help users find where this feature is.

Feel free to edit this / tweak further.